### PR TITLE
fix: transfer_name should only strip file extension, not truncate at first dot

### DIFF
--- a/offline_data_ingestion_and_query_interface/src/common_utils.py
+++ b/offline_data_ingestion_and_query_interface/src/common_utils.py
@@ -1,3 +1,4 @@
+import os
 import re
 import json
 import hashlib
@@ -12,8 +13,9 @@ sql_alchemy_helper = SQL_Alchemy_Helper(database_config)
 
 
 def transfer_name(original_name):
-    # 去除扩展名
-    name = original_name.split('.')[0]
+    # 去除扩展名（用 splitext 只去掉最后的 .xlsx/.xls，避免文件名中间的 "."
+    # 比如 "U.S." "F.C." 被 split('.')[0] 误截断导致大量文件撞名）
+    name = os.path.splitext(original_name)[0]
     
     # 替换非法字符为下划线
     name = re.sub(r'[^a-zA-Z0-9_]', '_', name)


### PR DESCRIPTION
## Bug

`transfer_name()` in `offline_data_ingestion_and_query_interface/src/common_utils.py` strips the file extension with:

```python
name = original_name.split('.')[0]
```

This splits on the **first** `.` in the filename, which is wrong whenever the filename itself contains a dot before `.xlsx`/`.xls` (e.g. abbreviations like `U.S.`, `F.C.`, `S.League`). Everything after the first dot is silently discarded.

## Impact (reproduced on the bundled `hybridqa/dev_excel` dataset, 3053 files)

- **50 / 3053** files have this truncation issue.
- **10** of them collapse into just **2** table names because their truncated prefixes collide, e.g.:
  - `Dancing_with_the_Stars_(U.S._season_2/5/7/11)_*.xlsx` -> all become `dancing_with_the_stars_u`
  - `List_of_U.S._*_populations/alumni_*.xlsx` -> all become `list_of_u`
- Since `insert_dataframe_batch` uses `if_exists='replace'`, the last-processed file of each colliding group silently overwrites the previous ones (both the MySQL table and the schema json), so **8 tables end up permanently lost** (3053 files -> only 3045 tables/schemas after ingestion).
- The other 40 files don't collide with anything else, so no data is lost, but their table names get semantically mangled (e.g. `List_of_Cardiff_City_F.C._records_and_statistics_2.xlsx` -> `list_of_cardiff_city_f`, losing `records_and_statistics_2`).

## Fix

Use `os.path.splitext()` instead, which only strips the actual trailing extension. Dots inside the filename are preserved and later normalized to underscores by the existing `re.sub(r'[^a-zA-Z0-9_]', '_', name)` step, so no other behavior changes.

## Verification

Re-ran ingestion on the same 3053-file `dev_excel` dataset after the fix:

- 3053 files -> **3053 unique table names**, 0 collisions (previously 3045 tables, 8 lost).
- The previously-colliding files now map to distinct names, e.g. `dancing_with_the_stars_u_s_season_5_0`, `_5_3`, `_2_3`, `_7_0`, `_11_2` are all separate tables again.
